### PR TITLE
US1002065: Updated copyright headers to 2025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2020-2024 Open Text.
+    Copyright 2020-2025 Open Text.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@
     </scm>
 
     <properties>
-        <copyrightYear>2024</copyrightYear>
+        <copyrightYear>2025</copyrightYear>
         <enforceCorrectDependencies>true</enforceCorrectDependencies>
         <enforceBannedDependencies>true</enforceBannedDependencies>
         <swagger-ui-version>5.29.1</swagger-ui-version>

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2020-2024 Open Text.
+    Copyright 2020-2025 Open Text.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/resources/opentext-config.js
+++ b/src/main/resources/opentext-config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Open Text.
+ * Copyright 2020-2025 Open Text.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/opentext-swagger-ui.css
+++ b/src/main/resources/opentext-swagger-ui.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2024 Open Text.
+ * Copyright 2020-2025 Open Text.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1002065